### PR TITLE
Use faraday to support following redirects

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,8 @@
 source "https://rubygems.org"
 
+gem "faraday", "0.9.2"
+gem "faraday_middleware", "0.10.0"
+
 group :test do
   gem "minitest", "5.8.4"
 end

--- a/lib/buienalarm_scraper.rb
+++ b/lib/buienalarm_scraper.rb
@@ -22,8 +22,8 @@ module Buienalarm
       # Details of how to scrape and use the data are documented in:
       # https://gist.github.com/jdennes/61322ea392df9120396eb6651f64e566
       conn = Faraday.new(:url => "http://www.buienalarm.nl") do |faraday|
-        faraday.use      FaradayMiddleware::FollowRedirects, limit: 3
-        faraday.adapter  Faraday.default_adapter
+        faraday.use     FaradayMiddleware::FollowRedirects, limit: 3
+        faraday.adapter Faraday.default_adapter
       end
       response = conn.get "/location/#{URI.escape(location)}"
       page = response.body

--- a/lib/buienalarm_scraper.rb
+++ b/lib/buienalarm_scraper.rb
@@ -1,4 +1,5 @@
-require "net/http"
+require "faraday"
+require "faraday_middleware"
 require "json"
 require "date"
 
@@ -19,8 +20,14 @@ module Buienalarm
     def self.scrape(location)
       # Details of how to scrape and use the data are documented in:
       # https://gist.github.com/jdennes/61322ea392df9120396eb6651f64e566
+      conn = Faraday.new(:url => "http://www.buienalarm.nl") do |faraday|
+        faraday.request  :url_encoded
+        faraday.use      FaradayMiddleware::FollowRedirects, limit: 3
+        faraday.adapter  Faraday.default_adapter
+      end
+      response = conn.get "/location/#{location}"
+      page = response.body
 
-      page = Net::HTTP.get "www.buienalarm.nl", "/location/#{location}"
       /^.*locationdata\['forecast'\] = (?<json>\{.*\});/i =~ page
       raise "No projected rainfall data for '#{location}' found" unless json
 

--- a/lib/buienalarm_scraper.rb
+++ b/lib/buienalarm_scraper.rb
@@ -21,7 +21,6 @@ module Buienalarm
       # Details of how to scrape and use the data are documented in:
       # https://gist.github.com/jdennes/61322ea392df9120396eb6651f64e566
       conn = Faraday.new(:url => "http://www.buienalarm.nl") do |faraday|
-        faraday.request  :url_encoded
         faraday.use      FaradayMiddleware::FollowRedirects, limit: 3
         faraday.adapter  Faraday.default_adapter
       end

--- a/lib/buienalarm_scraper.rb
+++ b/lib/buienalarm_scraper.rb
@@ -1,3 +1,4 @@
+require "uri"
 require "faraday"
 require "faraday_middleware"
 require "json"
@@ -24,7 +25,7 @@ module Buienalarm
         faraday.use      FaradayMiddleware::FollowRedirects, limit: 3
         faraday.adapter  Faraday.default_adapter
       end
-      response = conn.get "/location/#{location}"
+      response = conn.get "/location/#{URI.escape(location)}"
       page = response.body
 
       /^.*locationdata\['forecast'\] = (?<json>\{.*\});/i =~ page

--- a/test/test_buienalarm_scraper.rb
+++ b/test/test_buienalarm_scraper.rb
@@ -24,6 +24,18 @@ class TestBuienalarmScraper < Minitest::Test
     assert entry[:level].is_a? String
   end
 
+  def test_that_scrape_follows_redirects
+    location = "Rotterdam"
+    result = Buienalarm::Scraper.scrape(location)
+    # Requests to /location/Rotterdam should 302 to /location/rotterdam
+    assert result.is_a? Array
+    assert_equal 25, result.size
+    entry = result.first
+    assert entry[:time].is_a? DateTime
+    assert entry[:rainfall].is_a? Float
+    assert entry[:level].is_a? String
+  end
+
   def test_that_calculate_level_works
     levels = {
       "light"    => 0.25,

--- a/test/test_buienalarm_scraper.rb
+++ b/test/test_buienalarm_scraper.rb
@@ -36,6 +36,18 @@ class TestBuienalarmScraper < Minitest::Test
     assert entry[:level].is_a? String
   end
 
+  def test_that_scrape_handles_locations_including_spaces
+    location = "Den Haag"
+    result = Buienalarm::Scraper.scrape(location)
+    # Should request /location/Den%20Haag which should 302 to /location/denhaag
+    assert result.is_a? Array
+    assert_equal 25, result.size
+    entry = result.first
+    assert entry[:time].is_a? DateTime
+    assert entry[:rainfall].is_a? Float
+    assert entry[:level].is_a? String
+  end
+
   def test_that_calculate_level_works
     levels = {
       "light"    => 0.25,


### PR DESCRIPTION
Supports following redirects provided by Buienalarm.nl as well  as querying for locations containing spaces. For example:

```
› script/scrape "Den Haag"                      
===> Scraping Buienalarm.nl...

Projected rainfall for the next two hours in Den Haag:

13:20 - 0.00mm/hour (none)
13:25 - 0.00mm/hour (none)
...
```
