### PR TITLE
Use locality provided by Buienalarm.nl

### DIFF
--- a/script/scrape
+++ b/script/scrape
@@ -14,8 +14,8 @@ puts "===> Scraping Buienalarm.nl...\n\n"
 
 begin
   result = Buienalarm::Scraper.scrape(location)
-  puts "Projected rainfall for the next two hours in #{result[:locality]}:\n\n"
-  result[:projected_rainfall].each do |entry|
+  puts "Projected rainfall for the next two hours in #{result[:location]}:\n\n"
+  result[:rainfall].each do |entry|
     puts "#{entry[:time].strftime("%H:%M")} - %.2fmm/hour (#{entry[:level]})" % entry[:rainfall]
   end
 rescue Exception => e

--- a/script/scrape
+++ b/script/scrape
@@ -14,8 +14,8 @@ puts "===> Scraping Buienalarm.nl...\n\n"
 
 begin
   result = Buienalarm::Scraper.scrape(location)
-  puts "Projected rainfall for the next two hours in #{location}:\n\n"
-  result.each do |entry|
+  puts "Projected rainfall for the next two hours in #{result[:locality]}:\n\n"
+  result[:projected_rainfall].each do |entry|
     puts "#{entry[:time].strftime("%H:%M")} - %.2fmm/hour (#{entry[:level]})" % entry[:rainfall]
   end
 rescue Exception => e

--- a/test/test_buienalarm_scraper.rb
+++ b/test/test_buienalarm_scraper.rb
@@ -9,28 +9,32 @@ class TestBuienalarmScraper < Minitest::Test
     error = assert_raises RuntimeError do
       Buienalarm::Scraper.scrape(location)
     end
-    assert_equal "No projected rainfall data for '#{location}' found",
+    assert_equal "No projected rainfall data found for '#{location}'",
       error.message
   end
 
   def test_that_scrape_returns_valid_result
     location = "rotterdam"
     result = Buienalarm::Scraper.scrape(location)
-    assert result.is_a? Array
-    assert_equal 25, result.size
-    entry = result.first
+    assert result.is_a? Hash
+    assert_equal "Rotterdam", result[:location]
+    assert result[:rainfall].is_a? Array
+    assert_equal 25, result[:rainfall].size
+    entry = result[:rainfall].first
     assert entry[:time].is_a? DateTime
     assert entry[:rainfall].is_a? Float
     assert entry[:level].is_a? String
   end
 
   def test_that_scrape_follows_redirects
-    location = "Rotterdam"
+    location = "ROTTERDAM"
     result = Buienalarm::Scraper.scrape(location)
-    # Requests to /location/Rotterdam should 302 to /location/rotterdam
-    assert result.is_a? Array
-    assert_equal 25, result.size
-    entry = result.first
+    # Requests to /location/ROTTERDAM should 302 to /location/rotterdam
+    assert result.is_a? Hash
+    assert_equal "Rotterdam", result[:location]
+    assert result[:rainfall].is_a? Array
+    assert_equal 25, result[:rainfall].size
+    entry = result[:rainfall].first
     assert entry[:time].is_a? DateTime
     assert entry[:rainfall].is_a? Float
     assert entry[:level].is_a? String
@@ -40,9 +44,11 @@ class TestBuienalarmScraper < Minitest::Test
     location = "Den Haag"
     result = Buienalarm::Scraper.scrape(location)
     # Should request /location/Den%20Haag which should 302 to /location/denhaag
-    assert result.is_a? Array
-    assert_equal 25, result.size
-    entry = result.first
+    assert result.is_a? Hash
+    assert_equal "Den Haag", result[:location]
+    assert result[:rainfall].is_a? Array
+    assert_equal 25, result[:rainfall].size
+    entry = result[:rainfall].first
     assert entry[:time].is_a? DateTime
     assert entry[:rainfall].is_a? Float
     assert entry[:level].is_a? String


### PR DESCRIPTION
Include the location in the result provided by `Buienalarm::Scraper.scrape`. Changes the result to a `Hash`, which includes two entries, indexed by `:location` (a `String`) and `:rainfall` (an `Array` of `Hash`).

Means that if you went:

```
script/scrape "DEN HAAAG"
```

The actual location (`Den Haag`) used by Buienalarm.nl is available in the result, instead of `DEN HAAAG`:

```
===> Scraping Buienalarm.nl...

Projected rainfall for the next two hours in Den Haag:
...
```
